### PR TITLE
[codex] add post drawer transitions and theme polish

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -27,6 +27,7 @@ export default defineConfig({
     swup({
       theme: false,
       containers: ["main", "footer", ".banner-inner"],
+      routes: [{ name: "post", path: "/posts/:slug" }],
       smoothScrolling: true,
       progress: true,
       cache: true,

--- a/src/components/Banner.astro
+++ b/src/components/Banner.astro
@@ -17,7 +17,13 @@ let carouselImgsList = YukinaConfig.banners;
 const carouselAnimationTime = `${carouselImgsList.length * 6}s`;
 ---
 
-<div id="banner" class="banner onload-animation-fade-in">
+<div
+  id="banner"
+  class:list={[
+    "banner onload-animation-fade-in",
+    hasHeaderImg ? "banner-cover" : "banner-carousel",
+  ]}
+>
   <div class="transition-main banner-inner h-full w-full">
     {
       !hasHeaderImg && (
@@ -167,7 +173,7 @@ const carouselAnimationTime = `${carouselImgsList.length * 6}s`;
   }
 
   .cover {
-    @apply absolute left-0 top-0 z-0 block h-[var(--banner-height)] w-full overflow-hidden bg-white;
+    @apply absolute left-0 top-0 z-0 block h-[calc(var(--banner-height)*3/4)] w-full overflow-hidden bg-white lg:h-[var(--banner-height)];
   }
 
   .cover::before {
@@ -200,6 +206,10 @@ const carouselAnimationTime = `${carouselImgsList.length * 6}s`;
   .waves {
     @apply absolute -bottom-[1px] h-[10vh] max-h-[9.375rem] min-h-[3.125rem] w-full;
     @apply md:h-[15vh];
+  }
+
+  .banner-cover .waves {
+    @apply h-[7vh] max-h-24 min-h-12 md:h-[9vh];
   }
 
   .waves > .parallax use {

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -11,6 +11,24 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 <meta name="viewport" content="width=device-width,initial-scale=1" />
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 <meta name="generator" content={Astro.generator} />
+<meta name="color-scheme" content="light dark" />
+
+<script is:inline>
+  const storedTheme = (() => {
+    try {
+      return localStorage.getItem("theme");
+    } catch {
+      return null;
+    }
+  })();
+  const systemPrefersDark = window.matchMedia(
+    "(prefers-color-scheme: dark)",
+  ).matches;
+  const theme = storedTheme ?? (systemPrefersDark ? "dark" : "light");
+
+  document.documentElement.setAttribute("data-theme", theme);
+  document.documentElement.classList.toggle("dark", theme === "dark");
+</script>
 
 <!-- Canonical URL -->
 <link rel="canonical" href={canonicalURL} />

--- a/src/components/GlobalStyles.astro
+++ b/src/components/GlobalStyles.astro
@@ -49,6 +49,29 @@ import "overlayscrollbars/overlayscrollbars.css";
     --background-color: oklch(17.5% 0.015 var(--hue));
   }
 
+  :root.theme-transition,
+  :root.theme-transition *,
+  :root.theme-transition *::before,
+  :root.theme-transition *::after {
+    transition:
+      background-color 360ms ease,
+      color 360ms ease,
+      border-color 360ms ease,
+      fill 360ms ease,
+      stroke 360ms ease,
+      box-shadow 360ms ease,
+      opacity 360ms ease !important;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    :root.theme-transition,
+    :root.theme-transition *,
+    :root.theme-transition *::before,
+    :root.theme-transition *::after {
+      transition: none !important;
+    }
+  }
+
   .swup-progress-bar {
     height: 5px;
     background-color: var(--primary-color);

--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -282,13 +282,41 @@ const navCount = YukinaConfig.navigators.length;
     "theme-icon-dark",
   ) as any as SVGElement;
 
+  const systemThemeQuery = window.matchMedia("(prefers-color-scheme: dark)");
+
+  const getSystemTheme = () => (systemThemeQuery.matches ? "dark" : "light");
+  const getStoredTheme = () => {
+    try {
+      return localStorage.getItem("theme");
+    } catch {
+      return null;
+    }
+  };
+  const storeTheme = (theme: string) => {
+    try {
+      localStorage.setItem("theme", theme);
+    } catch {
+      // Ignore storage errors and keep the in-memory theme for this page.
+    }
+  };
+  let themeTransitionTimer: number | undefined;
+
+  const runThemeTransition = () => {
+    document.documentElement.classList.add("theme-transition");
+    window.clearTimeout(themeTransitionTimer);
+    themeTransitionTimer = window.setTimeout(() => {
+      document.documentElement.classList.remove("theme-transition");
+    }, 520);
+  };
+
   // Record the current theme
-  let currentTheme = localStorage.getItem("theme") || "light";
+  let currentTheme = getStoredTheme() ?? getSystemTheme();
 
   // Set theme
-  const setTheme = (theme: string) => {
+  const setTheme = (theme: string, persist = false, animate = false) => {
+    if (animate) runThemeTransition();
     document.documentElement.setAttribute("data-theme", theme);
-    localStorage.setItem("theme", theme);
+    if (persist) storeTheme(theme);
     currentTheme = theme;
 
     // Show/hide icons for different themes
@@ -305,7 +333,11 @@ const navCount = YukinaConfig.navigators.length;
 
   // Click to switch theme
   themeSwitcher.addEventListener("click", () => {
-    setTheme(currentTheme === "light" ? "dark" : "light");
+    setTheme(currentTheme === "light" ? "dark" : "light", true, true);
+  });
+
+  systemThemeQuery.addEventListener("change", () => {
+    if (!getStoredTheme()) setTheme(getSystemTheme(), false, true);
   });
 
   // Initialize

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -29,7 +29,7 @@ const {
 
 <Main title={title} subTitle={subTitle} bannerImage={bannerImage}>
   <!-- <Fragment set:html={tocHTMLString} /> -->
-  <div class="article-wrapper">
+  <div class="article-wrapper transition-post-drawer">
     <div class="article">
       <Markdown>
         <slot />

--- a/src/styles/transitions.css
+++ b/src/styles/transitions.css
@@ -20,3 +20,37 @@ html.is-animating.is-leaving .transition-leaving {
   transform: translateY(2rem);
   opacity: 0;
 }
+
+.transition-post-drawer {
+  transform-origin: bottom center;
+}
+
+html.is-changing.to-route-post .transition-leaving,
+html.is-changing.from-route-post .transition-leaving {
+  transition:
+    transform 520ms cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 420ms ease;
+  will-change: transform, opacity;
+}
+
+html.is-animating.to-route-post:not(.is-leaving) .transition-leaving {
+  transform: translateY(72vh);
+  opacity: 0;
+}
+
+html.is-animating.is-leaving.from-route-post .transition-leaving {
+  transform: translateY(72vh);
+  opacity: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html.is-changing.to-route-post .transition-leaving,
+  html.is-changing.from-route-post .transition-leaving {
+    transition: opacity 160ms ease;
+  }
+
+  html.is-animating.to-route-post:not(.is-leaving) .transition-leaving,
+  html.is-animating.is-leaving.from-route-post .transition-leaving {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary

- Add Swup route-aware drawer transitions for post pages, including back navigation.
- Fix post cover banner sizing and reduce cover-page wave overlap on narrower viewports.
- Make theme initialization follow the system preference by default and add a smooth light/dark transition.

## Why

Post navigation needed to feel like the article body opens and closes as a drawer. While testing that flow, banner cover sizing and the mobile wave layer caused visual overlap on some posts. Theme behavior also defaulted to light instead of following the system, and switching themes changed abruptly.

## Validation

- `vp run build`
- Commit hook ran `vp check --fix` on the staged files

## Notes

The repository still has broader pre-existing `vp check` issues outside this change set, and `vp test` reports no test files when run with the default Vitest pattern.